### PR TITLE
Use briefly to generate temp files for html template output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+_build
+
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/README.md
+++ b/README.md
@@ -97,3 +97,8 @@ before_script:
 - nvm install 8
 - npm i puppeteer-pdf -g
 ```
+
+### Configuring the `puppeteer-pdf` path
+
+You can set the `PUPPETEER_PDF_PATH` environment variable to point to the `puppeteer-pdf`
+executable.

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :puppeteer_pdf, exec_path: "/usr/bin/puppeteer-pdf"
+config :puppeteer_pdf, exec_path: System.get_env("PUPPETEER_PDF_PATH") || "/usr/bin/puppeteer-pdf"
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/puppeteer_pdf.ex
+++ b/lib/puppeteer_pdf.ex
@@ -8,39 +8,46 @@ defmodule PuppeteerPdf do
   """
   def generate_with_html(html, pdf_output_path, options \\ []) do
     # Random gen filename
-    case File.open "pdf_gen.html", [:write, :utf8] do
-        {:ok, file} ->
-          IO.write(file, html)
-          File.close file
+    {:ok, path} = Briefly.create(extname: ".html")
 
-          html_path = Path.absname("pdf_gen.html")
+    case File.open(path, [:write, :utf8]) do
+      {:ok, file} ->
+        IO.write(file, html)
+        File.close(file)
 
-          generate(html_path, pdf_output_path, options)
+        html_path = Path.absname(path)
 
-        {:error, error} -> {:error, error}
+        generate(html_path, pdf_output_path, options)
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
   def generate(html_input_path, pdf_output_path, options \\ []) do
-     exec_path = case Application.get_env(:puppeteer_pdf, :exec_path) do
-       nil -> "puppeteer-pdf"
-       value -> value
-     end
+    exec_path =
+      case Application.get_env(:puppeteer_pdf, :exec_path) do
+        nil -> "puppeteer-pdf"
+        value -> value
+      end
 
-     params = Enum.reduce(options, [html_input_path, "--path", pdf_output_path], fn ({key, value}), result ->
-       result ++ case key do
-         :header_template -> ["--headerTemplate=#{value}"]
-         :footer_template -> ["--footerTemplate=#{value}"]
-         :display_header_footer -> ["--displayHeaderFooter", to_string(value)]
-         :format -> ["--format", to_string(value)]
-         :print_background -> ["--printBackground", to_string(value)]
-         :margin_left -> ["--marginLeft", to_string(value)]
-         :margin_right -> ["--marginRight", to_string(value)]
-         :margin_top -> ["--marginTop", to_string(value)]
-         :margin_bottom -> ["--marginBottom", to_string(value)]
-         :debug -> ["--debug"]
-       end
-    end)
+    params =
+      Enum.reduce(options, [html_input_path, "--path", pdf_output_path], fn {key, value},
+                                                                            result ->
+        result ++
+          case key do
+            :header_template -> ["--headerTemplate=#{value}"]
+            :footer_template -> ["--footerTemplate=#{value}"]
+            :display_header_footer -> ["--displayHeaderFooter", to_string(value)]
+            :format -> ["--format", to_string(value)]
+            :print_background -> ["--printBackground", to_string(value)]
+            :margin_left -> ["--marginLeft", to_string(value)]
+            :margin_right -> ["--marginRight", to_string(value)]
+            :margin_top -> ["--marginTop", to_string(value)]
+            :margin_bottom -> ["--marginBottom", to_string(value)]
+            :debug -> ["--debug"]
+          end
+      end)
 
     case System.cmd(exec_path, params) do
       {cmd_response, _} ->

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule PuppeteerPdf.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.18", only: :dev}
+      {:ex_doc, "~> 0.18", only: :dev},
+      {:briefly, "~> 0.3"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
This adds a dependency on `briefly` for generating good temporary files.
This is a better choice than having a static file as that will be a
point of contention and lead to race condition errors / generally combat
concurrency.

It also adds the ability to set an env var, `PUPPETEER_PDF_PATH`, in
order to specify the path for the `puppeteer-pdf` binary.